### PR TITLE
Pass the installation_id when requesting a token

### DIFF
--- a/README.org
+++ b/README.org
@@ -309,9 +309,9 @@ vault login -method=userpass username=martin password=baillie
 vault write /github/token installation_id=987654 repository_ids=69857131 permissions=pull_requests=write
 # Permission denied:
 vault write -f /github/token
-vault write /github/token installation_id=987654  permissions=pull_requests=write
-vault write /github/token installation_id=987654  repository_ids=69857131 permissions=pull_requests=read
-vault write /github/token installation_id=987654  repository_ids=69857131 permissions=metadata=read
+vault write /github/token installation_id=987654 permissions=pull_requests=write
+vault write /github/token installation_id=987654 repository_ids=69857131 permissions=pull_requests=read
+vault write /github/token installation_id=987654 repository_ids=69857131 permissions=metadata=read
 vault write /github/token installation_id=987654 repository_ids=123 permissions=pull_requests=write
 vault write /github/token installation_id=987654 repository_ids=69857131
 vault write /github/token installation_id=123456 repository_ids=69857131

--- a/README.org
+++ b/README.org
@@ -290,8 +290,9 @@ Vault plugin.
 vault policy write github-only-prs -<<EOF
 path "github/token" {
   capabilities = ["update"]
-  required_parameters = ["permissions","repository_ids"]
+  required_parameters = ["installation_id","permissions","repository_ids"]
   allowed_parameters = {
+    "installation_id" = ["987654"]
     "repository_ids" = ["69857131"]
     "permissions"= ["pull_requests=write"]
   }
@@ -305,14 +306,15 @@ vault login -method=userpass username=martin password=baillie
 
 # Test the efficacy of the policy.
 # Successfully creates token:
-vault write /github/token repository_ids=69857131 permissions=pull_requests=write
+vault write /github/token installation_id=987654 repository_ids=69857131 permissions=pull_requests=write
 # Permission denied:
 vault write -f /github/token
-vault write /github/token permissions=pull_requests=write
-vault write /github/token repository_ids=69857131 permissions=pull_requests=read
-vault write /github/token repository_ids=69857131 permissions=metadata=read
-vault write /github/token repository_ids=123 permissions=pull_requests=write
-vault write /github/token repository_ids=69857131
+vault write /github/token installation_id=987654  permissions=pull_requests=write
+vault write /github/token installation_id=987654  repository_ids=69857131 permissions=pull_requests=read
+vault write /github/token installation_id=987654  repository_ids=69857131 permissions=metadata=read
+vault write /github/token installation_id=987654 repository_ids=123 permissions=pull_requests=write
+vault write /github/token installation_id=987654 repository_ids=69857131
+vault write /github/token installation_id=123456 repository_ids=69857131
    #+END_SRC
 
 * API
@@ -339,6 +341,7 @@ favour =repository_ids= (GitHub repository IDs are immutable) instead of
 =repositories= (GitHub repository names are mutable).
 #+end_quote
 
+- =installation_id= (int64) — the ID of the app installation.
 - =repositories= ([]string) — a list of the names of the repositories within the
   organisation that the installation token can access.
 - =repository_ids= ([]int64) — a list of the IDs of the repositories that the
@@ -357,16 +360,17 @@ vault read /github/token
 # Create a token with read permissions on the packages and write permissions on
 # the pull requests of repositories named "demo-repo" and ID 123.
 vault write /github/token \
+  installation_id=456 \
 	repository_ids=123 \
 	repositories=demo-repo \
 	permissions=packages=read \
 	permissions=pull_requests=write
 
 # Create a token with all permissions but only on the "demo-repo" repository.
-vault write /github/token repository_ids=123 repository_ids=456
+vault write /github/token installation_id=456 repository_ids=123 repository_ids=456
 
 # Create a token with all permissions but only on repositories 123 and 456.
-vault write /github/token repository_ids=123 repository_ids=456
+vault write /github/token installation_id=456 repository_ids=123 repository_ids=456
 
 # Create a token with write access to pull requests using read / GET.
 vault write /github/token permissions=pull_requests=write
@@ -376,6 +380,7 @@ vault write /github/token permissions=pull_requests=write
 # NOTE: Uses a Vault CLI JSON heredoc to submit the complex map type.
 vault write /github/token - <<EOF
 {
+"installation_id": 456,
 "repositories": ["demo-repo"],
 "repository_ids": [123,456],
 "permissions": {"metadata": "read", "pull_requests": "write"}
@@ -430,6 +435,7 @@ favour =repository_ids= (GitHub repository IDs are immutable) instead of
 =repositories= (GitHub repository names are mutable).
 #+end_quote
 
+- =installation_id= (int64) — the ID of the app installation.
 - =repositories= ([]string) — a list of the names of the repositories within the
   organisation that the installation token can access.
 - =repository_ids= ([]int64) — a list of the IDs of the repositories that the
@@ -456,6 +462,7 @@ returned will be constrained by that pre-configured permission set.
 # against three repositories.
 vault write /github/permissionset/demo-set - <<EOF
 {
+"installation_id": 987,
 "repositories": ["demo-repo"],
 "repository_ids": [123,456],
 "permissions": {"metadata": "read", "pull_requests": "write"}
@@ -463,6 +470,7 @@ vault write /github/permissionset/demo-set - <<EOF
 EOF
 # Or
 vault write /github/permissionset/demo-set \
+	installation_id=987 \
 	repositories=demo-repo \
 	repository_ids=123 \
 	repository_ids=456 \

--- a/README.org
+++ b/README.org
@@ -271,11 +271,8 @@ Vault plugin.
 5. Configure the plugin with the details noted from the previous section.
 
    #+BEGIN_SRC shell
-    # Write the configuration (discovered installation ID).
-    vault write /github/config app_id=<app_id> org_name=<org_name> prv_key=@<private_key_file>
-
-    # Write the configuration (explicit installation ID).
-    vault write /github/config app_id=<app_id> ins_id=<installation_id> prv_key=@<private_key_file>
+    # Write the configuration
+    vault write /github/config app_id=<app_id> prv_key=@<private_key_file>
 
     # (OPTIONAL) Confirm the configuration landed as you expected.
     vault read /github/config
@@ -497,18 +494,13 @@ General CRUD operations against the configuration of the plugin.
 
 *** Parameters
 - =app_id= (int64) — the Application ID of the GitHub App.
-- =ins_id= (int64) — the Installation ID of the GitHub App installation.
-- =org_name= (string) — the name of the organisation with the GitHub App installation.
 - =private_key= (string) — a private key configured in the GitHub App. This private key must be in PEM PKCS#1 RSAPrivateKey format. It is not returned with read requests for security reasons.
 - =base_url= (string) — the base URL for API requests (defaults to the public GitHub API).
 
 *** Examples
 #+BEGIN_SRC shell
-# Write the plugin configuration using the default base URL, reading the key from a file and discovering the installation ID by querying the organisation.
-vault write /github/config app_id=123 org_name=my-org prv_key=@key.pem
-
-# Write the plugin configuration using the default base URL, reading the key from a file and using an explicit installation ID.
-vault write /github/config app_id=123 ins_id=456 prv_key=@key.pem
+# Write the plugin configuration using the default base URL, and reading the key from a file.
+vault write /github/config app_id=123 prv_key=@key.pem
 
 # Read the plugin configuration.
 vault read /github/config

--- a/github/backend.go
+++ b/github/backend.go
@@ -158,8 +158,6 @@ func (b *backend) Client(s logical.Storage) (*Client, func(), error) {
 	b.Logger().Debug("created GitHub App installation client",
 		"base_url", config.BaseURL,
 		"app_id", strconv.Itoa(config.AppID),
-		"ins_id", strconv.Itoa(config.InsID),
-		"org_name", config.OrgName,
 	)
 	b.clientLock.RLock()
 

--- a/github/backend_test.go
+++ b/github/backend_test.go
@@ -103,21 +103,19 @@ func TestBackend_Config(t *testing.T) {
 		},
 		{
 			name: "HappyPath",
-			new: []byte(fmt.Sprintf(`{"%s":%d, "%s":%d}`,
-				keyAppID, testAppID1, keyInsID, testInsID1)),
+			new: []byte(fmt.Sprintf(`{"%s":%d}`,
+				keyAppID, testAppID1)),
 			exp: &Config{
 				AppID:   testAppID1,
-				InsID:   testInsID1,
 				BaseURL: githubPublicAPI,
 			},
 		},
 		{
 			name: "Organization",
-			new: []byte(fmt.Sprintf(`{"%s":%d, "%s":"%s"}`,
-				keyAppID, testAppID1, keyOrgName, testOrgName1)),
+			new: []byte(fmt.Sprintf(`{"%s":%d}`,
+				keyAppID, testAppID1)),
 			exp: &Config{
 				AppID:   testAppID1,
-				OrgName: testOrgName1,
 				BaseURL: githubPublicAPI,
 			},
 		},
@@ -169,7 +167,6 @@ func TestBackend_Client(t *testing.T) {
 
 		entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
 			AppID:   testAppID1,
-			InsID:   testInsID1,
 			PrvKey:  testPrvKeyValid,
 			BaseURL: testBaseURLValid,
 		})
@@ -203,7 +200,6 @@ func TestBackend_Client(t *testing.T) {
 
 		entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
 			AppID:   testAppID1,
-			InsID:   testInsID1,
 			PrvKey:  testPrvKeyValid,
 			BaseURL: testBaseURLValid,
 		})

--- a/github/client.go
+++ b/github/client.go
@@ -87,7 +87,7 @@ type tokenOptions struct {
 	// their access type.
 	Permissions map[string]string `json:"permissions,omitempty"`
 	// InstallationID is the installation ID  that the token can access.
-	InstallationID int `json:"installation_id"`
+	InstallationID int `json:"installation_id,omitempty"`
 	// RepositoryIDs are the repository IDs that the token can access.
 	RepositoryIDs []int `json:"repository_ids,omitempty"`
 	// Repositories are the repository names that the token can access.
@@ -163,6 +163,7 @@ func (c *Client) Token(ctx context.Context, opts *tokenOptions) (*logical.Respon
 	}
 
 	tokenRes := &logical.Response{Data: resData}
+	tokenRes.Data["installation_id"] = opts.InstallationID
 
 	// As per the issue request in https://git.io/JUhRk, return a Vault "lease"
 	// aligned to the GitHub token's `expires_at` field.

--- a/github/client_test.go
+++ b/github/client_test.go
@@ -130,8 +130,9 @@ func TestClient_Token(t *testing.T) {
 			}),
 			res: &logical.Response{
 				Data: map[string]interface{}{
-					"token":      testToken,
-					"expires_at": testTokenExp,
+					"token":           testToken,
+					"installation_id": testInsID1,
+					"expires_at":      testTokenExp,
 				},
 			},
 		},
@@ -140,9 +141,9 @@ func TestClient_Token(t *testing.T) {
 			ctx:  context.Background(),
 			opts: &tokenOptions{
 				InstallationID: testInsID1,
-				Repositories:  []string{testRepo1, testRepo2},
-				RepositoryIDs: []int{testRepoID1, testRepoID2},
-				Permissions:   testPerms,
+				Repositories:   []string{testRepo1, testRepo2},
+				RepositoryIDs:  []int{testRepoID1, testRepoID2},
+				Permissions:    testPerms,
 			},
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				t.Helper()
@@ -155,13 +156,15 @@ func TestClient_Token(t *testing.T) {
 				assert.NilError(t, json.NewDecoder(r.Body).Decode(&reqBody))
 				assert.Assert(t, is.Contains(reqBody, keyPerms))
 				assert.Assert(t, is.Contains(reqBody, keyRepoIDs))
+				assert.Assert(t, is.Contains(reqBody, keyInstallationID))
 				assert.Assert(t, is.Contains(reqBody, keyRepos))
 
 				w.Header().Set("Content-Type", "application/json")
 				body, _ := json.Marshal(map[string]interface{}{
-					"token":       testToken,
-					"expires_at":  testTokenExp,
-					"permissions": testPerms,
+					"token":           testToken,
+					"installation_id": testInsID1,
+					"expires_at":      testTokenExp,
+					"permissions":     testPerms,
 					"repositories": []map[string]interface{}{
 						{"id": testRepoID1, "name": testRepo1},
 						{"id": testRepoID2, "name": testRepo2},
@@ -172,9 +175,10 @@ func TestClient_Token(t *testing.T) {
 			}),
 			res: &logical.Response{
 				Data: map[string]interface{}{
-					"token":       testToken,
-					"expires_at":  testTokenExp,
-					"permissions": testPerms,
+					"token":           testToken,
+					"installation_id": testInsID1,
+					"expires_at":      testTokenExp,
+					"permissions":     testPerms,
 					"repositories": []map[string]interface{}{
 						{"id": testRepoID1, "name": testRepo1},
 						{"id": testRepoID2, "name": testRepo2},
@@ -189,7 +193,7 @@ func TestClient_Token(t *testing.T) {
 			opts: &tokenOptions{
 				InstallationID: testInsID1,
 			},
-			err:  errUnableToBuildAccessTokenReq,
+			err: errUnableToBuildAccessTokenReq,
 		},
 		{
 			name: "EOFResponse",

--- a/github/config.go
+++ b/github/config.go
@@ -28,12 +28,6 @@ type Config struct {
 	// AppID is the application identifier of the GitHub App.
 	AppID int `json:"app_id"`
 
-	// InsID is the installation identifier of the GitHub App.
-	InsID int `json:"ins_id"`
-
-	// OrgName is the organization name for the GitHub App.
-	OrgName string `json:"org_name"`
-
 	// PrvKey is the private for signing GitHub access token requests (JWTs).
 	// NOTE: Should be in a PEM PKCS#1 RSAPrivateKey format.
 	PrvKey string `json:"prv_key"`
@@ -85,20 +79,6 @@ func (c *Config) Update(d *framework.FieldData) (bool, error) {
 	if appID, ok := d.GetOk(keyAppID); ok {
 		if nv := appID.(int); c.AppID != nv {
 			c.AppID = nv
-			changed = true
-		}
-	}
-
-	if insID, ok := d.GetOk(keyInsID); ok {
-		if nv := insID.(int); c.InsID != nv {
-			c.InsID = nv
-			changed = true
-		}
-	}
-
-	if orgName, ok := d.GetOk(keyOrgName); ok {
-		if nv := orgName.(string); c.OrgName != nv {
-			c.OrgName = nv
 			changed = true
 		}
 	}

--- a/github/config_test.go
+++ b/github/config_test.go
@@ -98,14 +98,12 @@ func TestConfig_Update(t *testing.T) {
 			},
 			exp: &Config{
 				AppID:   testAppID2,
-				InsID:   testInsID1,
 				PrvKey:  testPrvKeyValid,
 				BaseURL: testBaseURLValid,
 			},
 			data: &framework.FieldData{
 				Raw: map[string]interface{}{
 					keyAppID:   testAppID2,
-					keyInsID:   testInsID1,
 					keyPrvKey:  testPrvKeyValid,
 					keyBaseURL: testBaseURLValid,
 				},

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -198,7 +198,6 @@ func TestIntegration(t *testing.T) {
 		// Ensure default values post-delete.
 		resData := resBody["data"].(map[string]interface{})
 		assert.Equal(t, resData[keyAppID], 0.0)
-		assert.Equal(t, resData[keyInsID], 0.0)
 		assert.Equal(t, resData[keyBaseURL], githubPublicAPI)
 	})
 }
@@ -211,8 +210,6 @@ func testWriteConfig(t *testing.T) {
 		fmt.Sprintf("/v1/github/%s", pathPatternConfig),
 		map[string]interface{}{
 			keyAppID:   appID,
-			keyInsID:   insID,
-			keyOrgName: orgName,
 			keyPrvKey:  prvKey,
 			keyBaseURL: baseURL,
 		},
@@ -241,8 +238,6 @@ func testReadConfig(t *testing.T) {
 
 	resData := resBody["data"].(map[string]interface{})
 	assert.Equal(t, resData[keyAppID], float64(appID))
-	assert.Equal(t, resData[keyInsID], float64(insID))
-	assert.Equal(t, resData[keyOrgName], orgName)
 	assert.Equal(t, resData[keyBaseURL], baseURL)
 }
 

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -29,8 +29,6 @@ var (
 
 	// Overridable GitHub App configuration.
 	appID   = envIntOrDefault(keyAppID, testAppID1)
-	insID   = envIntOrDefault(keyInsID, 0)
-	orgName = envStrOrDefault(keyOrgName, "")
 	prvKey  = envStrOrDefault(keyPrvKey, testPrvKeyValid)
 	baseURL = envStrOrDefault(keyBaseURL, "")
 

--- a/github/integration_test.go
+++ b/github/integration_test.go
@@ -248,9 +248,10 @@ func testWritePermissionSet(t *testing.T) {
 		http.MethodPost,
 		fmt.Sprintf("/v1/github/%s/test-set", pathPatternPermissionSet),
 		map[string]interface{}{
-			keyRepos:   []string{testRepo1, testRepo2},
-			keyRepoIDs: []int{testRepoID1, testRepoID2},
-			keyPerms:   testPerms,
+			keyInstallationID: testInsID1,
+			keyRepos:          []string{testRepo1, testRepo2},
+			keyRepoIDs:        []int{testRepoID1, testRepoID2},
+			keyPerms:          testPerms,
 		},
 	)
 	assert.NilError(t, err)
@@ -323,7 +324,9 @@ func testCreateToken(t *testing.T) {
 	res, err := vaultDo(
 		http.MethodPost,
 		fmt.Sprintf("/v1/github/%s", pathPatternToken),
-		nil,
+		map[string]interface{}{
+			keyInstallationID: testInsID1,
+		},
 	)
 	assert.NilError(t, err)
 	defer res.Body.Close()
@@ -354,10 +357,14 @@ func testCreatePermissionSetToken(t *testing.T) {
 	)
 	assert.NilError(t, err)
 	defer res.Body.Close()
-	assert.Assert(t, statusCode(res.StatusCode).Successful())
 
 	var resBody map[string]interface{}
 	err = json.NewDecoder(res.Body).Decode(&resBody)
+
+	t.Log(resBody)
+	t.Log(res.StatusCode)
+	assert.Assert(t, statusCode(res.StatusCode).Successful())
+
 	assert.NilError(t, err)
 	assert.Assert(t, is.Contains(resBody, "data"))
 
@@ -398,9 +405,10 @@ func testCreateTokenWithConstraints(t *testing.T) {
 		http.MethodPost,
 		fmt.Sprintf("/v1/github/%s", pathPatternToken),
 		map[string]interface{}{
-			keyRepos:   []string{testRepo1, testRepo2},
-			keyRepoIDs: []int{testRepoID1, testRepoID2},
-			keyPerms:   testPerms,
+			keyInstallationID: testInsID1,
+			keyRepos:          []string{testRepo1, testRepo2},
+			keyRepoIDs:        []int{testRepoID1, testRepoID2},
+			keyPerms:          testPerms,
 		},
 	)
 	assert.NilError(t, err)

--- a/github/path_config.go
+++ b/github/path_config.go
@@ -21,10 +21,6 @@ const (
 const (
 	keyAppID    = "app_id"
 	descAppID   = "Application ID of the GitHub App."
-	keyInsID    = "ins_id"
-	descInsID   = "Installation ID of the GitHub App."
-	keyOrgName  = "org_name"
-	descOrgName = "Organization name for the GitHub App."
 	keyPrvKey   = "prv_key"
 	descPrvKey  = "Private key for signing GitHub access token requests (JWTs)."
 	keyBaseURL  = "base_url"
@@ -49,14 +45,6 @@ func (b *backend) pathConfig() *framework.Path {
 				Type:        framework.TypeInt,
 				Description: descAppID,
 				Required:    true,
-			},
-			keyInsID: {
-				Type:        framework.TypeInt,
-				Description: descInsID,
-			},
-			keyOrgName: {
-				Type:        framework.TypeString,
-				Description: descOrgName,
 			},
 			keyPrvKey: {
 				Type:        framework.TypeString,
@@ -101,8 +89,6 @@ func (b *backend) pathConfigRead(
 	return &logical.Response{
 		Data: map[string]interface{}{
 			keyAppID:   c.AppID,
-			keyInsID:   c.InsID,
-			keyOrgName: c.OrgName,
 			keyBaseURL: c.BaseURL,
 		},
 	}, nil

--- a/github/path_config_test.go
+++ b/github/path_config_test.go
@@ -126,7 +126,7 @@ func testBackendPathConfigCreateUpdate(t *testing.T, op logical.Operation) {
 			b, storage := testBackend(t)
 
 			entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
-				AppID:   testAppID1,
+				AppID: testAppID1,
 			})
 			assert.NilError(t, err)
 			assert.Assert(t, entry != nil)

--- a/github/path_config_test.go
+++ b/github/path_config_test.go
@@ -30,7 +30,6 @@ func TestBackend_PathConfigRead(t *testing.T) {
 		})
 		assert.NilError(t, err)
 		assert.Assert(t, is.Contains(resp.Data, keyAppID))
-		assert.Assert(t, is.Contains(resp.Data, keyInsID))
 		assert.Assert(t, is.Contains(resp.Data, keyBaseURL))
 	})
 
@@ -41,7 +40,6 @@ func TestBackend_PathConfigRead(t *testing.T) {
 
 		entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
 			AppID:   testAppID1,
-			InsID:   testInsID1,
 			PrvKey:  testPrvKeyValid,
 			BaseURL: testBaseURLValid,
 		})
@@ -57,8 +55,6 @@ func TestBackend_PathConfigRead(t *testing.T) {
 
 		assert.Assert(t, is.Contains(resp.Data, keyAppID))
 		assert.Equal(t, testAppID1, resp.Data[keyAppID])
-		assert.Assert(t, is.Contains(resp.Data, keyInsID))
-		assert.Equal(t, testInsID1, resp.Data[keyInsID])
 		assert.Assert(t, is.Contains(resp.Data, keyBaseURL))
 		assert.DeepEqual(t, testBaseURLValid, resp.Data[keyBaseURL])
 	})
@@ -97,7 +93,6 @@ func testBackendPathConfigCreateUpdate(t *testing.T, op logical.Operation) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: testBaseURLValid,
 			},
@@ -108,20 +103,17 @@ func testBackendPathConfigCreateUpdate(t *testing.T, op logical.Operation) {
 		assert.NilError(t, err)
 		assert.Assert(t, config != nil)
 		assert.Equal(t, testAppID1, config.AppID)
-		assert.Equal(t, testInsID1, config.InsID)
 		assert.DeepEqual(t, testBaseURLValid, config.BaseURL)
 	})
 
 	tcConfig := map[string]map[string]interface{}{
 		"Installation": {
 			keyAppID:   testAppID2,
-			keyInsID:   testInsID2,
 			keyPrvKey:  testPrvKeyValid,
 			keyBaseURL: testBaseURLValid,
 		},
 		"Organization": {
 			keyAppID:   testAppID2,
-			keyOrgName: testOrgName2,
 			keyPrvKey:  testPrvKeyValid,
 			keyBaseURL: testBaseURLValid,
 		},
@@ -135,8 +127,6 @@ func testBackendPathConfigCreateUpdate(t *testing.T, op logical.Operation) {
 
 			entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
 				AppID:   testAppID1,
-				InsID:   testInsID1,
-				OrgName: testOrgName1,
 			})
 			assert.NilError(t, err)
 			assert.Assert(t, entry != nil)
@@ -155,11 +145,6 @@ func testBackendPathConfigCreateUpdate(t *testing.T, op logical.Operation) {
 			assert.NilError(t, err)
 			assert.Assert(t, config != nil)
 			assert.Equal(t, testAppID2, config.AppID)
-			if name == "Installation" {
-				assert.Equal(t, testInsID2, config.InsID)
-			} else {
-				assert.Equal(t, testOrgName2, config.OrgName)
-			}
 
 			assert.DeepEqual(t, testBaseURLValid, config.BaseURL)
 		})
@@ -257,7 +242,6 @@ func TestBackend_PathConfigDelete(t *testing.T) {
 
 		entry, err := logical.StorageEntryJSON(pathPatternConfig, &Config{
 			AppID:   testAppID1,
-			InsID:   testInsID1,
 			PrvKey:  testPrvKeyValid,
 			BaseURL: testBaseURLValid,
 		})

--- a/github/path_metrics.go
+++ b/github/path_metrics.go
@@ -40,7 +40,7 @@ var requestDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{
 	Name:       fmt.Sprintf("%s_request_duration_seconds", prefixMetrics),
 	Help:       "Total duration of Vault GitHub token requests in seconds.",
 	Objectives: map[float64]float64{0.5: 0.05, 0.9: 0.01, 0.99: 0.001},
-}, []string{"success", keyPerms, keyRepoIDs, keyRepos})
+}, []string{"success", keyInstallationID, keyPerms, keyRepoIDs, keyRepos})
 
 // revokeDuration records useful metric data about backend token revocations.
 var revokeDuration = prometheus.NewSummaryVec(prometheus.SummaryOpts{

--- a/github/path_permission_set.go
+++ b/github/path_permission_set.go
@@ -116,6 +116,7 @@ func (b *backend) pathPermissionSet() *framework.Path {
 			keyInstallationID: {
 				Type:        framework.TypeInt,
 				Description: descInstallationID,
+				Required:    true,
 			},
 			keyRepos: {
 				Type:        framework.TypeCommaStringSlice,
@@ -229,6 +230,9 @@ func (b *backend) pathPermissionSetCreateUpdate(
 	}
 
 	ps.TokenOptions.InstallationID = d.Get(keyInstallationID).(int)
+	if ps.TokenOptions.InstallationID == 0 {
+		return logical.ErrorResponse("%s is a required parameter", keyInstallationID), nil
+	}
 
 	if perms, ok := d.GetOk(keyPerms); ok {
 		ps.TokenOptions.Permissions = perms.(map[string]string)

--- a/github/path_permission_set.go
+++ b/github/path_permission_set.go
@@ -25,6 +25,7 @@ GitHub access tokens. Access tokens generated under a permission set subpath wil
 of permission on GitHub. The following is a sample payload:
 
 {
+	"installation_id": 123,
 	"repositories": [
 		"test-repo",
 		"demo-repo",
@@ -112,6 +113,10 @@ func (b *backend) pathPermissionSet() *framework.Path {
 				Type:        framework.TypeString,
 				Description: "Required. Name of the permission set.",
 			},
+			keyInstallationID: {
+				Type:        framework.TypeInt,
+				Description: descInstallationID,
+			},
 			keyRepos: {
 				Type:        framework.TypeCommaStringSlice,
 				Description: descRepos,
@@ -173,9 +178,10 @@ func (b *backend) pathPermissionSetRead(
 	}
 
 	data := map[string]interface{}{
-		keyRepos:   ps.TokenOptions.Repositories,
-		keyRepoIDs: ps.TokenOptions.RepositoryIDs,
-		keyPerms:   ps.TokenOptions.Permissions,
+		keyInstallationID: ps.TokenOptions.InstallationID,
+		keyRepos:          ps.TokenOptions.Repositories,
+		keyRepoIDs:        ps.TokenOptions.RepositoryIDs,
+		keyPerms:          ps.TokenOptions.Permissions,
 	}
 
 	return &logical.Response{
@@ -221,6 +227,8 @@ func (b *backend) pathPermissionSetCreateUpdate(
 			TokenOptions: new(tokenOptions),
 		}
 	}
+
+	ps.TokenOptions.InstallationID = d.Get(keyInstallationID).(int)
 
 	if perms, ok := d.GetOk(keyPerms); ok {
 		ps.TokenOptions.Permissions = perms.(map[string]string)

--- a/github/path_permission_set_test.go
+++ b/github/path_permission_set_test.go
@@ -62,9 +62,10 @@ func testBackendPathPermissionSetWrite(t *testing.T, op logical.Operation) {
 			Operation: op,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -79,9 +80,10 @@ func testBackendPathPermissionSetWrite(t *testing.T, op logical.Operation) {
 			Operation: op,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.Assert(t, err != nil)
@@ -92,9 +94,10 @@ func testBackendPathPermissionSetWrite(t *testing.T, op logical.Operation) {
 			Operation: op,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -114,9 +117,10 @@ func testBackendPathPermissionSetDelete(t *testing.T, op logical.Operation) {
 			Operation: logical.CreateOperation,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -181,9 +185,10 @@ func testBackendPathPermissionSetRead(t *testing.T, op logical.Operation) {
 			Operation: logical.CreateOperation,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -196,8 +201,10 @@ func testBackendPathPermissionSetRead(t *testing.T, op logical.Operation) {
 		})
 		assert.NilError(t, err)
 		permData := r.Data[keyPerms].(map[string]string)
+		installationIDData := r.Data[keyInstallationID].(int)
 		repoIDData := r.Data[keyRepoIDs].([]int)
 		repoData := r.Data[keyRepos].([]string)
+		assert.DeepEqual(t, installationIDData, testInsID1)
 		assert.DeepEqual(t, permData, testPerms)
 		assert.DeepEqual(t, repoIDData, []int{testRepoID1, testRepoID2})
 		assert.DeepEqual(t, repoData, []string{testRepo1, testRepo2})
@@ -246,9 +253,10 @@ func testBackendPathPermissionSetList(t *testing.T, op logical.Operation) {
 			Operation: logical.CreateOperation,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -272,9 +280,10 @@ func testBackendPathPermissionSetList(t *testing.T, op logical.Operation) {
 			Operation: logical.CreateOperation,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)

--- a/github/path_token.go
+++ b/github/path_token.go
@@ -23,12 +23,12 @@ const (
 const (
 	// NOTE: keys match GitHub installation permissions for ease of marshalling.
 	// SEE: https://git.io/JsQ7n
-	keyRepos           = "repositories"
-	descRepos          = "The repository names that the token should have access to"
-	keyRepoIDs         = "repository_ids"
-	descRepoIDs        = "The IDs of the repositories that the token can access."
-	keyPerms           = "permissions"
-	descPerms          = "The permissions granted to the token."
+	keyRepos    = "repositories"
+	descRepos   = "The repository names that the token should have access to"
+	keyRepoIDs  = "repository_ids"
+	descRepoIDs = "The IDs of the repositories that the token can access."
+	keyPerms    = "permissions"
+	descPerms   = "The permissions granted to the token."
 )
 
 const pathTokenHelpSyn = `
@@ -60,6 +60,7 @@ func (b *backend) pathToken() *framework.Path {
 			keyInstallationID: {
 				Type:        framework.TypeInt,
 				Description: descInstallationID,
+				Required:    true,
 			},
 			keyRepos: {
 				Type:        framework.TypeCommaStringSlice,
@@ -109,6 +110,9 @@ func (b *backend) pathTokenWrite(
 	opts := new(tokenOptions)
 
 	opts.InstallationID = d.Get(keyInstallationID).(int)
+	if opts.InstallationID == 0 {
+		return logical.ErrorResponse("%s is a required parameter", keyInstallationID), nil
+	}
 
 	if perms, ok := d.GetOk(keyPerms); ok {
 		opts.Permissions = perms.(map[string]string)

--- a/github/path_token.go
+++ b/github/path_token.go
@@ -16,14 +16,19 @@ import (
 const pathPatternToken = "token"
 
 const (
+	keyInstallationID  = "installation_id"
+	descInstallationID = "The Id of the installation that the token should have access to"
+)
+
+const (
 	// NOTE: keys match GitHub installation permissions for ease of marshalling.
 	// SEE: https://git.io/JsQ7n
-	keyRepos    = "repositories"
-	descRepos   = "The repository names that the token should have access to"
-	keyRepoIDs  = "repository_ids"
-	descRepoIDs = "The IDs of the repositories that the token can access."
-	keyPerms    = "permissions"
-	descPerms   = "The permissions granted to the token."
+	keyRepos           = "repositories"
+	descRepos          = "The repository names that the token should have access to"
+	keyRepoIDs         = "repository_ids"
+	descRepoIDs        = "The IDs of the repositories that the token can access."
+	keyPerms           = "permissions"
+	descPerms          = "The permissions granted to the token."
 )
 
 const pathTokenHelpSyn = `
@@ -31,23 +36,31 @@ Create and return a token using the GitHub secrets plugin.
 `
 
 var pathTokenHelpDesc = fmt.Sprintf(`
-Create and return a token using the GitHub secrets plugin, optionally
-constrained by the above parameters.
+Create and return a token using the GitHub secrets plugin.
 
-NOTE: '%s' is a slice of repository names.
+NOTE: '%s' is an installation ID.
+
+Optionally, the thoken can be constrained by the following parameters:
+
+* '%s' is a slice of repository names.
 These must be the short names of repositories under the organisation.
 
-NOTE: '%s' is a slice of repository IDs.
+* '%s' is a slice of repository IDs.
 The quickest way to find a repository ID: https://stackoverflow.com/a/47223479
 
-NOTE: '%s' is a map of permission names to their access type (read or write).
+* '%s' is a map of permission names to their access type (read or write).
+
 Permission names taken from: https://developer.github.com/v3/apps/permissions
-`, keyRepos, keyRepoIDs, keyPerms)
+`, keyInstallationID, keyRepos, keyRepoIDs, keyPerms)
 
 func (b *backend) pathToken() *framework.Path {
 	return &framework.Path{
 		Pattern: pathPatternToken,
 		Fields: map[string]*framework.FieldSchema{
+			keyInstallationID: {
+				Type:        framework.TypeInt,
+				Description: descInstallationID,
+			},
 			keyRepos: {
 				Type:        framework.TypeCommaStringSlice,
 				Description: descRepos,
@@ -95,6 +108,8 @@ func (b *backend) pathTokenWrite(
 	// Safely parse any options from interface types.
 	opts := new(tokenOptions)
 
+	opts.InstallationID = d.Get(keyInstallationID).(int)
+
 	if perms, ok := d.GetOk(keyPerms); ok {
 		opts.Permissions = perms.(map[string]string)
 	}
@@ -115,14 +130,16 @@ func (b *backend) pathTokenWrite(
 			"took", duration.String(),
 			"err", err,
 			"permissions", opts.Permissions,
+			"installation_id", fmt.Sprint(opts.InstallationID),
 			"repository_ids", fmt.Sprint(opts.RepositoryIDs),
 			"repositories", fmt.Sprint(opts.Repositories),
 		)
 		requestDuration.With(prometheus.Labels{
-			"success":  strconv.FormatBool(err == nil),
-			keyPerms:   strconv.FormatBool(len(opts.Permissions) > 0),
-			keyRepoIDs: strconv.FormatBool(len(opts.RepositoryIDs) > 0),
-			keyRepos:   strconv.FormatBool(len(opts.Repositories) > 0),
+			"success":         strconv.FormatBool(err == nil),
+			keyInstallationID: fmt.Sprint(opts.InstallationID),
+			keyPerms:          strconv.FormatBool(len(opts.Permissions) > 0),
+			keyRepoIDs:        strconv.FormatBool(len(opts.RepositoryIDs) > 0),
+			keyRepos:          strconv.FormatBool(len(opts.Repositories) > 0),
 		}).Observe(duration.Seconds())
 	}(time.Now())
 

--- a/github/path_token_permission_set.go
+++ b/github/path_token_permission_set.go
@@ -18,18 +18,22 @@ Create and return a token using the GitHub secrets plugin.
 `
 
 var pathTokenPermissinonSetHelpDesc = fmt.Sprintf(`
-Create and return a token using the GitHub secrets plugin, optionally
-constrained by the above parameters.
+Create and return a token using the GitHub secrets plugin.
 
-NOTE: '%s' is a slice of repository names.
+NOTE: '%s' is an installation ID.
+
+Optionally, the thoken can be constrained by the following parameters:
+
+* '%s' is a slice of repository names.
 These must be the short names of repositories under the organisation.
 
-NOTE: '%s' is a slice of repository IDs.
+* '%s' is a slice of repository IDs.
 The quickest way to find a repository ID: https://stackoverflow.com/a/47223479
 
-NOTE: '%s' is a map of permission names to their access type (read or write).
+* '%s' is a map of permission names to their access type (read or write).
+
 Permission names taken from: https://developer.github.com/v3/apps/permissions
-`, keyRepos, keyRepoIDs, keyPerms)
+`, keyInstallationID, keyRepos, keyRepoIDs, keyPerms)
 
 func (b *backend) pathTokenPermissionSet() *framework.Path {
 	return &framework.Path{
@@ -89,14 +93,16 @@ func (b *backend) pathTokenPermissionSetWrite(
 			"took", duration.String(),
 			"err", err,
 			"permissions", opts.Permissions,
+			"installation_id", fmt.Sprint(opts.InstallationID),
 			"repository_ids", fmt.Sprint(opts.RepositoryIDs),
 			"repositories", fmt.Sprint(opts.Repositories),
 		)
 		requestDuration.With(prometheus.Labels{
-			"success":  strconv.FormatBool(err == nil),
-			keyPerms:   strconv.FormatBool(len(opts.Permissions) > 0),
-			keyRepoIDs: strconv.FormatBool(len(opts.RepositoryIDs) > 0),
-			keyRepos:   strconv.FormatBool(len(opts.Repositories) > 0),
+			"success":         strconv.FormatBool(err == nil),
+			keyInstallationID: fmt.Sprint(opts.InstallationID),
+			keyPerms:          strconv.FormatBool(len(opts.Permissions) > 0),
+			keyRepoIDs:        strconv.FormatBool(len(opts.RepositoryIDs) > 0),
+			keyRepos:          strconv.FormatBool(len(opts.Repositories) > 0),
 		}).Observe(duration.Seconds())
 	}(time.Now())
 

--- a/github/path_token_permission_set_test.go
+++ b/github/path_token_permission_set_test.go
@@ -58,9 +58,10 @@ func testBackendPathTokenPermissionSetWrite(t *testing.T, op logical.Operation) 
 			Operation: op,
 			Path:      "permissionset/foo",
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)

--- a/github/path_token_permission_set_test.go
+++ b/github/path_token_permission_set_test.go
@@ -47,7 +47,6 @@ func testBackendPathTokenPermissionSetWrite(t *testing.T, op logical.Operation) 
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},
@@ -112,7 +111,6 @@ func testBackendPathTokenPermissionSetWrite(t *testing.T, op logical.Operation) 
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},

--- a/github/path_token_test.go
+++ b/github/path_token_test.go
@@ -48,7 +48,6 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},
@@ -97,7 +96,6 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:  testAppID1,
-				keyInsID:  testInsID1,
 				keyPrvKey: testPrvKeyValid,
 			},
 		})
@@ -138,7 +136,6 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},

--- a/github/path_token_test.go
+++ b/github/path_token_test.go
@@ -148,6 +148,9 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Storage:   storage,
 			Operation: op,
 			Path:      pathPatternToken,
+			Data: map[string]interface{}{
+				keyInstallationID: testInsID1,
+			},
 		})
 		assert.Assert(t, is.Nil(r))
 		assert.Assert(t, errors.Is(err, errUnableToCreateAccessToken))

--- a/github/path_token_test.go
+++ b/github/path_token_test.go
@@ -59,9 +59,10 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Operation: op,
 			Path:      pathPatternToken,
 			Data: map[string]interface{}{
-				keyRepos:   []string{testRepo1, testRepo2},
-				keyRepoIDs: []int{testRepoID1, testRepoID2},
-				keyPerms:   testPerms,
+				keyInstallationID: testInsID1,
+				keyRepos:          []string{testRepo1, testRepo2},
+				keyRepoIDs:        []int{testRepoID1, testRepoID2},
+				keyPerms:          testPerms,
 			},
 		})
 		assert.NilError(t, err)
@@ -106,9 +107,10 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 			Operation: op,
 			Path:      pathPatternToken,
 			Data: map[string]interface{}{
-				keyRepos:   "not a string slice",
-				keyRepoIDs: "not an int slice",
-				keyPerms:   "not a map of string to string",
+				keyInstallationID: "not an int",
+				keyRepos:          "not a string slice",
+				keyRepoIDs:        "not an int slice",
+				keyPerms:          "not a map of string to string",
 			},
 		})
 

--- a/github/path_token_test.go
+++ b/github/path_token_test.go
@@ -86,6 +86,34 @@ func testBackendPathTokenWrite(t *testing.T, op logical.Operation) {
 		assert.ErrorContains(t, err, fmtErrConfRetrieval)
 	})
 
+	t.Run("MissingInstallationID", func(t *testing.T) {
+		t.Parallel()
+
+		b, storage := testBackend(t)
+
+		_, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: logical.CreateOperation,
+			Path:      pathPatternConfig,
+			Data: map[string]interface{}{
+				keyAppID:  testAppID1,
+				keyPrvKey: testPrvKeyValid,
+			},
+		})
+		assert.NilError(t, err)
+
+		r, err := b.HandleRequest(context.Background(), &logical.Request{
+			Storage:   storage,
+			Operation: op,
+			Path:      pathPatternToken,
+			Data:      map[string]interface{}{},
+		})
+
+		assert.NilError(t, err)
+		assert.Assert(t, r != nil)
+		assert.Assert(t, strings.Contains(r.Data["error"].(string), "installation_id is a required parameter"))
+	})
+
 	t.Run("FailedOptionsParsing", func(t *testing.T) {
 		t.Parallel()
 

--- a/github/revocation_test.go
+++ b/github/revocation_test.go
@@ -35,7 +35,6 @@ func TestBackend_Revoke(t *testing.T) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},
@@ -83,7 +82,6 @@ func TestBackend_Revoke(t *testing.T) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:  testAppID1,
-				keyInsID:  testInsID1,
 				keyPrvKey: testPrvKeyValid,
 			},
 		})
@@ -123,7 +121,6 @@ func TestBackend_Revoke(t *testing.T) {
 			Path:      pathPatternConfig,
 			Data: map[string]interface{}{
 				keyAppID:   testAppID1,
-				keyInsID:   testInsID1,
 				keyPrvKey:  testPrvKeyValid,
 				keyBaseURL: ts.URL,
 			},


### PR DESCRIPTION
This PR removes the installation / organization parameters from the backend configuration and makes it part of the token request and permissionset machinery. This makes it a fairly solid API break, and I don't know how to reckon with that.

Note that this also drops support for specifying an organization's name as the naive way to implement that is by looking up the org's name on every token create request, which seemed a bit heavy. Maybe a lookup cache could be added? I didn't know how to do this.

I note that I'm not much of a Go programmer, but I've done my best to do things in line with the rest of the codebase.

Closes #20 and part of #53