### PR TITLE
Reduce memory consumption for high-load deployment

### DIFF
--- a/github/config.go
+++ b/github/config.go
@@ -31,6 +31,10 @@ type Config struct {
 	// BaseURL is the base URL for API requests.
 	// Defaults to GitHub's public API.
 	BaseURL string `json:"base_url"`
+
+	// IncludeRepositoryMetadata controls filtering of the 'repositories' key returned on repository-filtered tokens
+	// Defaults to returning full repository metadata; returns a minimised list of repository names if set to false
+	IncludeRepositoryMetadata bool `json:"include_repository_metadata"`
 }
 
 // NewConfig returns a pre-configured Config struct.
@@ -75,6 +79,13 @@ func (c *Config) Update(d *framework.FieldData) (bool, error) {
 	if appID, ok := d.GetOk(keyAppID); ok {
 		if nv := appID.(int); c.AppID != nv {
 			c.AppID = nv
+			changed = true
+		}
+	}
+
+	if includeRepositoryMetadata, ok := d.GetOk(includeRepositoryMetadataKey); ok {
+		if nv := includeRepositoryMetadata.(bool); c.IncludeRepositoryMetadata != nv {
+			c.IncludeRepositoryMetadata = nv
 			changed = true
 		}
 	}

--- a/github/path_config.go
+++ b/github/path_config.go
@@ -19,12 +19,15 @@ const (
 )
 
 const (
-	keyAppID    = "app_id"
-	descAppID   = "Application ID of the GitHub App."
-	keyPrvKey   = "prv_key"
-	descPrvKey  = "Private key for signing GitHub access token requests (JWTs)."
-	keyBaseURL  = "base_url"
-	descBaseURL = "Base URL for API requests (defaults to the public GitHub API)."
+	keyAppID                     = "app_id"
+	descAppID                    = "Application ID of the GitHub App."
+	keyPrvKey                    = "prv_key"
+	includeRepositoryMetadataKey = "include_repository_metadata"
+
+	descPrvKey                       = "Private key for signing GitHub access token requests (JWTs)."
+	descIncludeRepositoryMetadataKey = "If set to true, the token lease response 'data.repositories' sub-field will be minimized to 'data.repositories.*.names'"
+	keyBaseURL                       = "base_url"
+	descBaseURL                      = "Base URL for API requests (defaults to the public GitHub API)."
 )
 
 const pathConfigHelpSyn = `
@@ -50,6 +53,12 @@ func (b *backend) pathConfig() *framework.Path {
 				Type:        framework.TypeString,
 				Description: descPrvKey,
 				Required:    true,
+			},
+			includeRepositoryMetadataKey: {
+				Type:        framework.TypeBool,
+				Description: descIncludeRepositoryMetadataKey,
+				Required:    false,
+				Default:     true,
 			},
 			keyBaseURL: {
 				Type:        framework.TypeString,
@@ -87,8 +96,9 @@ func (b *backend) pathConfigRead(
 	}
 
 	resData := map[string]any{
-		keyAppID:   c.AppID,
-		keyBaseURL: c.BaseURL,
+		keyAppID:                     c.AppID,
+		keyBaseURL:                   c.BaseURL,
+		includeRepositoryMetadataKey: c.IncludeRepositoryMetadata,
 	}
 
 	// We don't return the key but indicate its presence for a better UX.


### PR DESCRIPTION
# Goal
Per-repository, this opt-in change, reduces memory consumption per-token / per-repository from `6.5KB` to `0.5KB` . Which significantly reduces `oom-killed` events, due to memory exhaustion, on `high-load` deployments.

**Use-case 1**: When using 32 repositories, this results in a memory footprint reduction of 2 orders of magnitude equating to a reduction from `220KB` to `1.8KB`.
**Use-case 2**:  When using 40 repositories, this also results in a memory footprint reduction of 2 orders of magnitude equating to a reduction from `275KB` to `2197B`.


# Changed
Added a new [Config](https://github.com/martinbaillie/vault-plugin-secrets-github/blob/master/github/config.go#L23) key `include_repository_metadata` (**defaults** to `true` to allow opt-in to new behaviour) which allows the `repositories` key contained in the [token response](https://github.com/martinbaillie/vault-plugin-secrets-github/blob/master/github/client.go#L219) to be minimised to only containing the repository names contained in the `repositories.*.name` keys.

## Configuring
The new `include_repository_metadata` takes `bool` type values and can be provided as per the below example:
```sh
$ vault write <mount>/config app_id=<your_app_id> prv_key=<your_prv_key> include_repository_metadata=false
```

## Test procedure taken
```console
$ make build
# installed the plugin on my local `vault server -dev -config=vault.hcl` instance
$ vault secrets enable -path=github -plugin-name=vault-plugin-secrets-github -plugin-version=2.0.1 plugin
# configured the plugin to be bound to the repository `651070198` (which points to `https://github.com/pcanilho/vault-plugin-secrets-github`)
$ vault write github/permissionset/test installation_id=38403580 repository_ids=651070198
# configured the plugin with vanilla settings
$ vault write github/config app_id=344956 prv_key=@pcanilho.test.pem 
# confirmed functional state
$ vault read -format=json  github/token/test 
---
{
  ...
  "lease_id": "github/token/test/KuQLAEaVyvaGK4opYTfSrtN0",
  ...
  "repositories": [
      { <very_large_payload> }
  ...
}
---
# re-configured the plugin to use the newly created flag
$ vault write github/config app_id=344956 prv_key=@pcanilho.test.pem include_repository_metadata=false
# confirmed functional state with minimised `repositories` output
$ vault read -format=json  github/token/test 
---
{
  "request_id": "0b08da06-7205-edd6-3918-1574abc5165b",
  "lease_id": "github/token/test/hhL1lXJtwR7OUMxLgHMhPwX7",
  "lease_duration": 3599,
  "renewable": false,
  "data": {
    "expires_at": "2023-06-09T07:08:13Z",
    "installation_id": 38403580,
    "permissions": {
      "checks": "write",
      "contents": "read",
      "metadata": "read",
      "pull_requests": "write",
      "statuses": "write"
    },
    "repositories": [
      "vault-plugin-secrets-github"
    ],
    "repository_selection": "selected",
    "token": "<secret>"
  },
  "warnings": null
---
```

