### PR TITLE
feat: initializes proxy for Transport if needed

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -75,6 +75,7 @@ func NewClient(config *Config) (*Client, error) {
 			Timeout: reqTimeout / 2,
 		}).DialContext,
 		TLSHandshakeTimeout: reqTimeout / 2,
+		Proxy:               http.ProxyFromEnvironment,
 	}
 
 	// Create an GitHub App installation authenticated clone of transport.


### PR DESCRIPTION
This PR intends to initialize the http client with a proxy configuration, when _HTTP_PROXY_, _HTTPS_PROXY_ and/or _NO_PROXY_ environment variables are available in plugin's execution context.