### PR TITLE
fix: Use a case-insensitive organization name lookup

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -300,7 +300,7 @@ func (c *Client) installationID(ctx context.Context, orgName string) (int, error
 	}
 
 	for _, v := range instResult {
-		if v.Account.Login == orgName {
+		if strings.EqualFold(v.Account.Login, orgName) {
 			return v.ID, nil
 		}
 	}


### PR DESCRIPTION
GitHub Organization names are not case-sensitive, see [Get an Organization][get-org]. This updates the installation ID lookup is updated to reflect this. Technically they are case preserving, but we don't need to return or store the organization names so that's not an issue for us.

Related: integrations/terraform-provider-github#196

[get-org]: https://docs.github.com/en/enterprise-cloud@latest/rest/orgs/orgs?apiVersion=2022-11-28#get-an-organization