### PR TITLE
fix: client timeouts with >250 repositories

### DIFF
--- a/github/client.go
+++ b/github/client.go
@@ -64,7 +64,7 @@ func NewClient(config *Config) (*Client, error) {
 	}
 
 	// A sensible request timeout.
-	reqTimeout := time.Millisecond * 5000
+	reqTimeout := time.Millisecond * 10000
 
 	// Initialise a new transport instead of using Go's default. This transport
 	// has explicit timeouts and sensible defaults for max connections per host
@@ -72,9 +72,9 @@ func NewClient(config *Config) (*Client, error) {
 	// with one host).
 	transport := &http.Transport{
 		DialContext: (&net.Dialer{
-			Timeout: reqTimeout / 2,
+			Timeout: reqTimeout / 4,
 		}).DialContext,
-		TLSHandshakeTimeout: reqTimeout / 2,
+		TLSHandshakeTimeout: reqTimeout / 4,
 		Proxy:               http.ProxyFromEnvironment,
 	}
 


### PR DESCRIPTION
* GitHub support installation token requests for up to 500 named repositories. However, the default 5s client timeout begins to intermittently fail with requests targeting over ~250 repositories. Increase the client timeout to 10s to mitigate this.

@martinbaillie : Any chance we could get a patch release for this? It's been hitting us quite hard for the past couple of weeks.